### PR TITLE
Improve page redirecting

### DIFF
--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -25,7 +25,7 @@
   <h2 class="font-bold mt-4">3. Ihre Rechte</h2>
   <p>Sie haben das Recht auf Auskunft, Berichtigung, Löschung und Widerspruch gegen die Verarbeitung Ihrer Daten.</p>
 
-  <p class="mt-4"><a href="index.html" class="button">Zurück</a></p>
+  <p class="mt-4"><a onclick="window.location = document.referrer" class="button">Zurück</a></p>
 </div>
 
 </body>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -19,7 +19,7 @@
   <p>Schweiz</p>
   <p>Geschäftsführer: Jan Atzgerstorfer</p>
   <p>Email: info@kennzahlen-cockpit.ch</p>
-  <p class="mt-4"><a href="index.html" class="button">Zurück</a></p>
+  <p class="mt-4"><a onclick="window.location = document.referrer;" class="button">Zurück</a></p>
 </div>
 
 </body>

--- a/src/js/pages/loginPage.js
+++ b/src/js/pages/loginPage.js
@@ -16,7 +16,15 @@ if (form) {
 
         if (jsonData.hasOwnProperty("token")) {
             sessionStorage.setItem("token", jsonData.token);
-            window.location.href = "index.html";
+
+            /* If the user has been on a different page when the login prompt was triggered, he will be sent back
+            to his last location (referrer). If not, he will be sent to index.html.
+            Source: https://chatgpt.com/share/6807b56d-66e4-8011-aaeb-5d074c8b0489 */
+            if (window.history.length <= 1) {
+                window.location = "index.html";
+            } else {
+                window.location = document.referrer
+            }
         }
     });
 }


### PR DESCRIPTION
Check if the user was redirected from a subpage of the cockpit to the login page and if yes, send him back where he came from.
Prevent key figure data from unloading when a subpage like "Impressum" or "Datenschutz" was visited