### PR TITLE
fixed issue 42

### DIFF
--- a/src/js/components/customKeyFigureSidebar.js
+++ b/src/js/components/customKeyFigureSidebar.js
@@ -153,7 +153,7 @@ function setPageToEditMode(customKeyFigureId, customKeyFigureName, sidebarItem) 
 
 
 function addCustomKeyFigureEventListeners() {
-    Array.from(document.getElementsByClassName("sidebar-item")).forEach(item => {
+    Array.from(document.getElementsByClassName("sidebar-item-content-wrapper")).forEach(item => {
         item.addEventListener("click", async (event)=>{
             const customKeyFigureId = event.currentTarget.dataset.customKeyFigureId
             const customKeyFigureName = event.currentTarget.dataset.customKeyFigureName


### PR DESCRIPTION
fixed issue #42 by only applying edit mode eventListeners to the text content wrapper of the sidebar elements. This way, edit mode doesn't get triggered when clicking the delete button on the sidebar elements