### PR TITLE
fixed issue 44

### DIFF
--- a/src/js/components/customKeyFigureSidebar.js
+++ b/src/js/components/customKeyFigureSidebar.js
@@ -155,11 +155,11 @@ function setPageToEditMode(customKeyFigureId, customKeyFigureName, sidebarItem) 
 function addCustomKeyFigureEventListeners() {
     Array.from(document.getElementsByClassName("sidebar-item-content-wrapper")).forEach(item => {
         item.addEventListener("click", async (event)=>{
-            const customKeyFigureId = event.currentTarget.dataset.customKeyFigureId
-            const customKeyFigureName = event.currentTarget.dataset.customKeyFigureName
+            const customKeyFigureId = event.currentTarget.parentNode.dataset.customKeyFigureId
+            const customKeyFigureName = event.currentTarget.parentNode.dataset.customKeyFigureName
             await editCustomKeyFigure(customKeyFigureId)
 
-            setPageToEditMode(customKeyFigureId, customKeyFigureName, item)
+            setPageToEditMode(customKeyFigureId, customKeyFigureName, item.parentNode)
 
         })
     })


### PR DESCRIPTION
After the eventListeners that trigger edit mode where updated to be only applied to the content wrapper in the custom key figure sidebar elements instead of the whole element, these two lines were caused to always be undefined:
```
const customKeyFigureId = event.currentTarget.dataset.customKeyFigureId
const customKeyFigureName = event.currentTarget.dataset.customKeyFigureName
```
This is because the dataset which saves the custom key figure ID and name is a property of the entire sidebar element, not of the content-wrapper. The problem was fixed by accessing dataset of the parentNode of the event's currentTarget which is the sidebar element:
```
const customKeyFigureId = event.currentTarget.parentNode.dataset.customKeyFigureId
const customKeyFigureName = event.currentTarget.parentNode.dataset.customKeyFigureName
```