### PR TITLE
block new company text field when user doesn't have admin privileges

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,7 +88,7 @@
 
   <div class="sidebar w-64 bg-white shadow p-4 border-l border-gray-200">
     <h2 class="text-lg font-semibold mb-4">Unternehmen</h2>
-    <input type="text" id="companyNameInput" class="form-input" maxlength="30" placeholder="Neues Unternehmen" />
+    <input type="text" id="companyNameInput" class="greyed-out form-input" maxlength="30" placeholder="Neues Unternehmen" disabled/>
     <div id="companyContainer">
 
     </div>

--- a/src/js/components/companySidebar.js
+++ b/src/js/components/companySidebar.js
@@ -50,18 +50,27 @@ async function loadCompanySidebar() {
         })
     }
 
+    const newCompanyTextField = document.getElementById("companyNameInput")
+    const companySideBarDeleteButtons = Array.from(document.getElementsByClassName("sidebar-delete-button"))
+
     const userIsAdmin = await checkUserPrivileges()
     if (userIsAdmin === true) {
-        // The delete buttons should only have eventListeners if the user is allowed to delete companies
+        // The delete buttons should only have eventListeners if the user is allowed to delete companies (admins)
         addCompanyDeleteButtonEventListeners()
-        Array.from(document.getElementsByClassName("sidebar-delete-button")).forEach(button => {
+        companySideBarDeleteButtons.forEach(button => {
             button.classList.remove("greyed-out")
         })
+        // Only enable the new company text field if the user is allowed to create new companies (admins)
+        newCompanyTextField.classList.remove("greyed-out")
+        newCompanyTextField.removeAttribute("disabled")
     } else {
         // If the user doesn't have admin privileges, the delete buttons are greyed out
-        Array.from(document.getElementsByClassName("sidebar-delete-button")).forEach(button => {
+        companySideBarDeleteButtons.forEach(button => {
             button.classList.add("greyed-out")
         })
+        // The new company text field is also greyed out and disabled
+        newCompanyTextField.classList.add("greyed-out")
+        newCompanyTextField.setAttribute("disabled", "true")
         }
     addCompanyElementEventListeners()
 }


### PR DESCRIPTION
The text field to create a new company inside the company sidebar will now also be greyed out and disabled for standard users