### PR TITLE
Improve historic key figure tab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,19 +44,19 @@
 
         <div id="dropdownMenu" class="absolute left-0 mt-1 hidden z-50 w-full bg-white border border-gray-300 rounded shadow max-h-64 overflow-y-auto">
           <ul class="text-sm text-gray-700">
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="fixedAssetCoverage1" class="mr-2">Anlagedeckungsgrad 1</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="fixedAssetCoverage2" class="mr-2">Anlagedeckungsgrad 2</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="cashRatio" class="mr-2">Liquiditätsgrad 1</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="quickCash" class="mr-2">Liquiditätsgrad 2</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="currentRatio" class="mr-2">Liquiditätsgrad 3</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="debtRatio" class="mr-2">Verschuldungsgrad</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="equityRatio" class="mr-2">Eigenfinanzierungsgrad</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="fixedAssetIntensity" class="mr-2">Anlageintensität</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="profitMargin" class="mr-2">Gewinnmarge</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="roa" class="mr-2">Gesamtkapitalrendite</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="roe" class="mr-2">Eigenkapitalrendite</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="selfFinancingRatio" class="mr-2">Selbstfinanzierungsgrad</label></li>
-            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="workingCapitalIntensity" class="mr-2">Umlaufintensität</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="fixedAssetCoverage1" class=" key-figure-checkbox mr-2">Anlagedeckungsgrad 1</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="fixedAssetCoverage2" class=" key-figure-checkbox mr-2">Anlagedeckungsgrad 2</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="cashRatio" class=" key-figure-checkbox mr-2">Liquiditätsgrad 1</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="quickCash" class=" key-figure-checkbox mr-2">Liquiditätsgrad 2</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="currentRatio" class=" key-figure-checkbox mr-2">Liquiditätsgrad 3</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="debtRatio" class=" key-figure-checkbox mr-2">Verschuldungsgrad</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="equityRatio" class=" key-figure-checkbox mr-2">Eigenfinanzierungsgrad</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="fixedAssetIntensity" class=" key-figure-checkbox mr-2">Anlageintensität</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="profitMargin" class=" key-figure-checkbox mr-2">Gewinnmarge</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="roa" class=" key-figure-checkbox mr-2">Gesamtkapitalrendite</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="roe" class=" key-figure-checkbox mr-2">Eigenkapitalrendite</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="selfFinancingRatio" class=" key-figure-checkbox mr-2">Selbstfinanzierungsgrad</label></li>
+            <li><label class="flex items-center px-4 py-2 hover:bg-gray-100"><input type="checkbox" value="workingCapitalIntensity" class=" key-figure-checkbox mr-2">Umlaufintensität</label></li>
           </ul>
         </div>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -32,9 +32,7 @@
 
 
     <div class="control-section flex justify-between items-center mb-4">
-      <div class="relative w-80">
-        <label class="block font-medium text-gray-700 mb-1">Auswertung auswählen</label>
-
+      <div class="relative w-80" id="historicTabDropdown">
         <div id="dropdownToggle" class="select-dropdown bg-white border border-gray-300 rounded p-2 cursor-pointer relative">
           <span id="dropdownLabel">Kennzahlen auswählen</span>
           <svg class="absolute right-3 top-3 w-4 h-4 text-gray-600 pointer-events-none" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
   <script type="module" src="../src/js/components/companySidebar.js" defer></script>
   <script type="module" src="../src/js/keyFigureData/loadCompanyData.js" defer></script>
   <script type="module" src="../src/js/auth/auth.js" defer></script>
-  <script type="module" src="../src/js/pages/mainPage.js" defer></script>
+  <script type='module' src="../src/js/pages/mainPage.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 

--- a/src/js/components/companySidebar.js
+++ b/src/js/components/companySidebar.js
@@ -108,7 +108,13 @@ function addCompanyElementEventListeners() {
             const companyId = companyItem.dataset.companyId
             const companyName = companyItem.dataset.companyName
 
-            window.location.href = `${window.location.pathname}?id=${companyId}&company=${companyName}`
+            const url = new URL(window.location.href)
+            url.searchParams.set("id", companyId)
+            url.searchParams.set("company", companyName)
+
+            window.history.replaceState(null, '', url.toString())
+            window.location.reload()
+
         })
     })
 }

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -1,191 +1,23 @@
-import {getCurrentKeyFigureData} from "../keyFigureData/loadCompanyData.js";
-import {checkUserPrivileges} from "../utils/userPrivilegeVerification.js";
-import {sendServerRequest} from "../utils/serverResponseHandling.js";
+import { sendServerRequest } from '../utils/serverResponseHandling.js';
+import { checkUserPrivileges } from '../utils/userPrivilegeVerification.js';
+import { getCurrentKeyFigureData } from '../keyFigureData/loadCompanyData.js';
 
-function logout() {
-    sessionStorage.removeItem("token");
-    window.location.href = "login.html";
+export function showTab(tab) {
+    document.getElementById("graph-section").classList.add("hidden");
+    document.getElementById("table-section").classList.add("hidden");
+
+    document.getElementById(`${tab}-section`).classList.remove("hidden");
+
+    document.querySelectorAll(".tab-button").forEach(button => {
+        button.classList.remove("border-gray-800");
+        button.classList.add("border-transparent");
+    });
+
+    document.getElementById(`tab-${tab}`).classList.add("border-gray-800");
+    document.getElementById(`tab-${tab}`).classList.remove("border-transparent");
 }
 
-document.addEventListener("DOMContentLoaded", async () => {
-    document.getElementById("logoutButton").addEventListener("click", logout);
-
-    function showTab(tab) {
-        document.getElementById("graph-section").classList.add("hidden");
-        document.getElementById("table-section").classList.add("hidden");
-
-        document.getElementById(tab + "-section").classList.remove("hidden");
-
-        document.querySelectorAll(".tab-button").forEach(button => {
-            button.classList.remove("border-gray-800");
-            button.classList.add("border-transparent");
-        });
-
-        document.getElementById("tab-" + tab).classList.add("border-gray-800");
-        document.getElementById("tab-" + tab).classList.remove("border-transparent");
-    }
-
-    if (document.getElementById("tab-graph") && document.getElementById("tab-table")) {
-        showTab('table');
-
-        document.getElementById("tab-graph").addEventListener("click", () => showTab('graph'));
-        document.getElementById("tab-table").addEventListener("click", () => showTab('table'));
-    }
-
-    restrictCustomKeyFigureAccess();
-
-    const urlParams = new URLSearchParams(window.location.search);
-    const companyId = urlParams.get("id");
-    if (!companyId) return;
-
-    if (urlParams.has("id")) {
-        getCurrentKeyFigureData().then(insertKeyFiguresToTable);
-    }
-
-    const chartCanvas = document.getElementById("historicChart");
-    const ctx = chartCanvas.getContext("2d");
-    let chart;
-
-    const dropdownToggle = document.getElementById("dropdownToggle");
-    const dropdownMenu = document.getElementById("dropdownMenu");
-    const dropdownLabel = document.getElementById("dropdownLabel");
-    const dropdownList = dropdownMenu.querySelector("ul");
-
-    const labelToKey = {
-        "Liquiditätsgrad 1": "cashRatio",
-        "Liquiditätsgrad 2": "quickCash",
-        "Liquiditätsgrad 3": "currentRatio",
-        "Verschuldungsgrad": "debtRatio",
-        "Eigenfinanzierungsgrad": "equityRatio",
-        "Anlagedeckungsgrad 1": "fixedAssetCoverage1",
-        "Anlagedeckungsgrad 2": "fixedAssetCoverage2",
-        "Anlageintensität": "fixedAssetIntensity",
-        "Gewinnmarge": "profitMargin",
-        "Gesamtkapitalrendite": "roa",
-        "Eigenkapitalrendite": "roe",
-        "Selbstfinanzierungsgrad": "selfFinancingRatio",
-        "Umlaufintensität": "workingCapitalIntensity"
-    };
-
-    // Add custom key figures to dropdown
-    const customKeyFigures = await sendServerRequest("GET", "http://localhost:5000/customKeyFigures", null, false);
-    customKeyFigures.forEach(fig => {
-        const listItem = document.createElement("li");
-        listItem.innerHTML = `
-            <label class="flex items-center px-4 py-2 hover:bg-gray-100">
-                <input type="checkbox" value="${fig.name}" class="mr-2">${fig.name}
-            </label>
-        `;
-        dropdownList.appendChild(listItem);
-        labelToKey[fig.name] = fig.name;
-    });
-
-    function setupCheckboxListeners(container) {
-        container.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-            cb.addEventListener("change", () => {
-                const selected = Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
-                    .map(c => c.parentElement.textContent.trim());
-                dropdownLabel.textContent = selected.length > 0 ? selected.join(", ") : "Kennzahlen auswählen";
-                renderMultiChart(selected);
-            });
-        });
-    }
-
-    setupCheckboxListeners(dropdownList);
-
-    dropdownToggle.addEventListener("click", () => dropdownMenu.classList.toggle("hidden"));
-    document.addEventListener("click", e => {
-        if (!dropdownToggle.contains(e.target) && !dropdownMenu.contains(e.target)) {
-            dropdownMenu.classList.add("hidden");
-        }
-    });
-
-    let historicData;
-    try {
-        historicData = await sendServerRequest("GET", `http://localhost:5000/keyFigures/historic/${companyId}`, null, false);
-    } catch (err) {
-        chartCanvas.parentElement.innerHTML = `<p class="text-center text-red-500">Fehler beim Laden der Daten.</p>`;
-        return;
-    }
-
-    async function renderMultiChart(selectedLabels) {
-        if (chart) chart.destroy();
-
-        if (selectedLabels.length === 0) {
-            chartCanvas.parentElement.innerHTML = "<p class='text-center text-gray-500'>Bitte Kennzahlen auswählen.</p>";
-            return;
-        }
-
-        const datasets = [];
-        let commonLabels = [];
-
-        for (const label of selectedLabels) {
-            const key = labelToKey[label];
-            if (!key) continue;
-
-            let keyData = historicData[key];
-
-            if (!keyData) {
-                try {
-                    const customDataObj = await sendServerRequest("GET", `http://localhost:5000/customKeyFigures/historic/${companyId}/${key}`, null, false);
-                    keyData = customDataObj;
-                } catch (err) {
-                    console.error(`Fehler beim Laden der Custom-Kennzahl '${key}':`, err);
-                    continue;
-                }
-            }
-
-            if (!Array.isArray(keyData) || keyData.length === 0) continue;
-            keyData.sort((a, b) => (a.period || 0) - (b.period || 0));
-
-            const labels = [];
-            const values = [];
-
-            keyData.forEach(entry => {
-                const label = entry.period || "Unbekannt";
-                const value = entry.key_figure ?? entry.customKeyFigure ?? entry.value;
-                if (value !== undefined && value !== null) {
-                    labels.push(label);
-                    values.push(value);
-                }
-            });
-
-            if (labels.length === 0 || values.length === 0) continue;
-            if (commonLabels.length === 0) commonLabels = labels;
-
-            datasets.push({
-                label: label,
-                data: values,
-                fill: false,
-                tension: 0.3
-            });
-        }
-
-        if (datasets.length === 0) {
-            chartCanvas.parentElement.innerHTML = "<p class='text-center text-gray-500'>Keine Daten gefunden oder Fehler beim Abrufen.</p>";
-            return;
-        }
-
-        chart = new Chart(ctx, {
-            type: "line",
-            data: {
-                labels: commonLabels,
-                datasets: datasets
-            },
-            options: {
-                responsive: true,
-                scales: {
-                    y: { beginAtZero: false }
-                },
-                plugins: {
-                    legend: { position: "top" }
-                }
-            }
-        });
-    }
-});
-
-function restrictCustomKeyFigureAccess() {
+export function restrictCustomKeyFigureAccess() {
     const button = document.getElementById("customKeyFigureEditorButton")
     if (!button) return;
     checkUserPrivileges().then((result) => {
@@ -199,7 +31,7 @@ function restrictCustomKeyFigureAccess() {
     })
 }
 
-async function insertKeyFiguresToTable(data) {
+export async function insertKeyFiguresToTable(data) {
     const figures = data.keyFigures;
     const period = data.period ? data.period : "";
     const urlParams = new URLSearchParams(window.location.search);
@@ -262,3 +94,174 @@ async function insertKeyFiguresToTable(data) {
         targetTable.appendChild(row);
     }
 }
+
+async function renderMultiChart(selectedLabels, ctx, chartCanvas, companyId, labelToKey, setChart, getChart) {
+    const currentChart = getChart();
+    if (currentChart) currentChart.destroy();
+    setChart(null);
+
+    if (selectedLabels.length === 0) {
+        chartCanvas.parentElement.innerHTML = "<p class='text-center text-gray-500'>Bitte Kennzahlen auswählen.</p>";
+        return;
+    }
+
+    let historicData;
+    try {
+        historicData = await sendServerRequest("GET", `http://localhost:5000/keyFigures/historic/${companyId}`, null, false);
+    } catch (err) {
+        chartCanvas.parentElement.innerHTML = `<p class=\"text-center text-red-500\">Fehler beim Laden der Daten.</p>`;
+        return;
+    }
+
+    const datasets = [];
+    let commonLabels = [];
+
+    for (const label of selectedLabels) {
+        const key = labelToKey[label];
+        if (!key) continue;
+
+        let keyData = historicData[key];
+
+        if (!keyData) {
+            try {
+                const customDataObj = await sendServerRequest("GET", `http://localhost:5000/customKeyFigures/historic/${companyId}/${key}`, null, false);
+                keyData = customDataObj;
+            } catch (err) {
+                console.error(`Fehler beim Laden der Custom-Kennzahl '${key}':`, err);
+                continue;
+            }
+        }
+
+        if (!Array.isArray(keyData) || keyData.length === 0) continue;
+        keyData.sort((a, b) => (a.period || 0) - (b.period || 0));
+
+        const labels = [];
+        const values = [];
+
+        keyData.forEach(entry => {
+            const label = entry.period || "Unbekannt";
+            const value = entry.key_figure ?? entry.customKeyFigure ?? entry.value;
+            if (value !== undefined && value !== null) {
+                labels.push(label);
+                values.push(value);
+            }
+        });
+
+        if (labels.length === 0 || values.length === 0) continue;
+        if (commonLabels.length === 0) commonLabels = labels;
+
+        datasets.push({
+            label: label,
+            data: values,
+            fill: false,
+            tension: 0.3
+        });
+    }
+
+    if (datasets.length === 0) {
+        chartCanvas.parentElement.innerHTML = "<p class='text-center text-gray-500'>Keine Daten gefunden oder Fehler beim Abrufen.</p>";
+        return;
+    }
+
+    const chart = new Chart(ctx, {
+        type: "line",
+        data: {
+            labels: commonLabels,
+            datasets: datasets
+        },
+        options: {
+            responsive: true,
+            scales: { y: { beginAtZero: false } },
+            plugins: { legend: { position: "top" } }
+        }
+    });
+
+    setChart(chart);
+}
+
+function setupCheckboxListeners(container, dropdownLabel, ctx, chartCanvas, companyId, labelToKey, setChart, getChart) {
+    container.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+        cb.addEventListener("change", () => {
+            const selected = Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
+                .map(c => c.parentElement.textContent.trim());
+            dropdownLabel.textContent = selected.length > 0 ? selected.join(", ") : "Kennzahlen auswählen";
+            renderMultiChart(selected, ctx, chartCanvas, companyId, labelToKey, setChart, getChart);
+        });
+    });
+}
+
+async function setupDropdown(companyId) {
+    const chartCanvas = document.getElementById("historicChart");
+    const ctx = chartCanvas.getContext("2d");
+    let chart = null;
+
+    const dropdownToggle = document.getElementById("dropdownToggle");
+    const dropdownMenu = document.getElementById("dropdownMenu");
+    const dropdownLabel = document.getElementById("dropdownLabel");
+    const dropdownList = dropdownMenu.querySelector("ul");
+
+    const labelToKey = {
+        "Liquiditätsgrad 1": "cashRatio",
+        "Liquiditätsgrad 2": "quickCash",
+        "Liquiditätsgrad 3": "currentRatio",
+        "Verschuldungsgrad": "debtRatio",
+        "Eigenfinanzierungsgrad": "equityRatio",
+        "Anlagedeckungsgrad 1": "fixedAssetCoverage1",
+        "Anlagedeckungsgrad 2": "fixedAssetCoverage2",
+        "Anlageintensität": "fixedAssetIntensity",
+        "Gewinnmarge": "profitMargin",
+        "Gesamtkapitalrendite": "roa",
+        "Eigenkapitalrendite": "roe",
+        "Selbstfinanzierungsgrad": "selfFinancingRatio",
+        "Umlaufintensität": "workingCapitalIntensity"
+    };
+
+    const customKeyFigures = await sendServerRequest("GET", "http://localhost:5000/customKeyFigures", null, false);
+    customKeyFigures.forEach(fig => {
+        const listItem = document.createElement("li");
+        listItem.innerHTML = `
+            <label class="flex items-center px-4 py-2 hover:bg-gray-100">
+                <input type="checkbox" value="${fig.name}" class="mr-2">${fig.name}
+            </label>
+        `;
+        dropdownList.appendChild(listItem);
+        labelToKey[fig.name] = fig.name;
+    });
+
+    setupCheckboxListeners(dropdownList, dropdownLabel, ctx, chartCanvas, companyId, labelToKey, (newChart) => chart = newChart, () => chart);
+
+    dropdownToggle.addEventListener("click", () => dropdownMenu.classList.toggle("hidden"));
+    document.addEventListener("click", e => {
+        if (!dropdownToggle.contains(e.target) && !dropdownMenu.contains(e.target)) {
+            dropdownMenu.classList.add("hidden");
+        }
+    });
+}
+
+export function logout() {
+    localStorage.removeItem("token");
+    window.location.href = "login.html";
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+    document.getElementById("logoutButton").addEventListener("click", logout);
+
+    if (document.getElementById("tab-graph") && document.getElementById("tab-table")) {
+        showTab('table');
+
+        document.getElementById("tab-graph").addEventListener("click", () => showTab('graph'));
+        document.getElementById("tab-table").addEventListener("click", () => showTab('table'));
+    }
+
+    restrictCustomKeyFigureAccess();
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const companyId = urlParams.get("id");
+    if (!companyId) return;
+
+    if (urlParams.has("id")) {
+        getCurrentKeyFigureData().then(insertKeyFiguresToTable);
+    }
+
+    setupDropdown(companyId);
+});

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -101,24 +101,29 @@ export async function insertKeyFiguresToTable(data) {
     }
 }
 
+function displayNoKeyFiguresSelectedMessage() {
+    const chartCanvas = document.getElementById("historicChart")
+    if (chartCanvas) {
+        chartCanvas.classList.add("hidden")
+
+        const existingMsg = document.getElementById("noChartMessage")
+        if (!existingMsg) {
+            const p = document.createElement("p")
+            p.id = "noChartMessage"
+            p.className = "text-center text-gray-500"
+            p.textContent = "Bitte Kennzahlen auswählen."
+            chartCanvas.parentElement.appendChild(p)
+        }
+    }
+}
+
 async function renderMultiChart(selectedLabels, ctx, chartCanvas, companyId, labelToKey, setChart, getChart) {
     const currentChart = getChart();
     if (currentChart) currentChart.destroy();
     setChart(null);
 
     if (selectedLabels.length === 0) {
-        if (chartCanvas) {
-            chartCanvas.classList.add("hidden");
-
-            const existingMsg = document.getElementById("noChartMessage");
-            if (!existingMsg) {
-                const p = document.createElement("p");
-                p.id = "noChartMessage";
-                p.className = "text-center text-gray-500";
-                p.textContent = "Bitte Kennzahlen auswählen.";
-                chartCanvas.parentElement.appendChild(p);
-            }
-        }
+        displayNoKeyFiguresSelectedMessage()
         return;
     }
 
@@ -379,6 +384,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     if (url.searchParams.has("id")) {
         getCurrentKeyFigureData().then(insertKeyFiguresToTable);
+    }
+
+    if (getSelectedKeyFiguresFromUrlParams().length === 0) {
+        displayNoKeyFiguresSelectedMessage()
     }
 
     setupDropdown(companyId);

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -127,13 +127,27 @@ async function findCustomKeyFigure(customKeyFigureName) {
 }
 
 function multiplyKeyFigureValuesBasedOnType(historicDataObject) {
+    /**
+     * Takes a historic data object and multiplies all the historic key figure values based on their type.
+     * Percentage key figures are delivered by the server as the raw ratios,
+     * so they need to be multiplied with 100.
+     * Numeric key figures are delivered by the server as accounting short figures,
+     * so they need to be multiplied with 1000.
+     *
+     * @param {Object} historicDataObject - An object containing historic data for multiple key figures
+     * @returns {Object} The modified historicDataObject with the multiplied values
+     */
+
     for (const [keyFigureName, historicValueArray] of Object.entries(historicDataObject)) {
         let multiplicator = 100
+
+        // Only custom key figures can have a non-percentage type, so it is checked, if it is one
         const foundCustomKeyFigure = findCustomKeyFigure(keyFigureName)
         if (foundCustomKeyFigure && foundCustomKeyFigure.type === "numeric") {
             multiplicator = 1000
         }
 
+        // Multiply the key figure values for all years in the historical array
         historicValueArray.forEach(yearlyValue => {
             yearlyValue.key_figure *= multiplicator
         })

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -149,7 +149,7 @@ function multiplyKeyFigureValuesBasedOnType(historicDataObject) {
 
         // Multiply the key figure values for all years in the historical array
         historicValueArray.forEach(yearlyValue => {
-            yearlyValue.key_figure *= multiplicator
+            yearlyValue.key_figure = (yearlyValue.key_figure * multiplicator).toFixed(0)
         })
     }
 

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -195,16 +195,6 @@ async function renderMultiChart(selectedLabels, ctx, chartCanvas, companyId, lab
 
         let keyData = historicData[key];
 
-        if (!keyData) {
-            try {
-                const customDataObj = await sendServerRequest("GET", `http://localhost:5000/customKeyFigures/historic/${companyId}/${key}`, null, false);
-                keyData = customDataObj;
-            } catch (err) {
-                console.error(`Fehler beim Laden der Custom-Kennzahl '${key}':`, err);
-                continue;
-            }
-        }
-
         if (!Array.isArray(keyData) || keyData.length === 0) continue;
         keyData.sort((a, b) => (a.period || 0) - (b.period || 0));
 

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -101,15 +101,36 @@ async function renderMultiChart(selectedLabels, ctx, chartCanvas, companyId, lab
     setChart(null);
 
     if (selectedLabels.length === 0) {
-        chartCanvas.parentElement.innerHTML = "<p class='text-center text-gray-500'>Bitte Kennzahlen auswählen.</p>";
+        if (chartCanvas) {
+            chartCanvas.classList.add("hidden");
+
+            const existingMsg = document.getElementById("noChartMessage");
+            if (!existingMsg) {
+                const p = document.createElement("p");
+                p.id = "noChartMessage";
+                p.className = "text-center text-gray-500";
+                p.textContent = "Bitte Kennzahlen auswählen.";
+                chartCanvas.parentElement.appendChild(p);
+            }
+        }
         return;
     }
+
 
     let historicData;
     try {
         historicData = await sendServerRequest("GET", `http://localhost:5000/keyFigures/historic/${companyId}`, null, false);
     } catch (err) {
-        chartCanvas.parentElement.innerHTML = `<p class=\"text-center text-red-500\">Fehler beim Laden der Daten.</p>`;
+        chartCanvas.classList.add("hidden");
+
+        const messageElement = document.getElementById("noChartMessage");
+        if (!messageElement) {
+            const p = document.createElement("p");
+            p.id = "noChartMessage";
+            p.className = "text-center text-gray-500";
+            p.textContent = "Bitte Kennzahlen auswählen.";
+            chartCanvas.parentElement.appendChild(p);
+        }
         return;
     }
 
@@ -162,6 +183,10 @@ async function renderMultiChart(selectedLabels, ctx, chartCanvas, companyId, lab
         chartCanvas.parentElement.innerHTML = "<p class='text-center text-gray-500'>Keine Daten gefunden oder Fehler beim Abrufen.</p>";
         return;
     }
+    const existingMsg = document.getElementById("noChartMessage");
+    if (existingMsg) existingMsg.remove();
+    chartCanvas.classList.remove("hidden");
+
 
     const chart = new Chart(ctx, {
         type: "line",
@@ -192,6 +217,7 @@ function setupCheckboxListeners(container, dropdownLabel, ctx, chartCanvas, comp
 
 async function setupDropdown(companyId) {
     const chartCanvas = document.getElementById("historicChart");
+    if (!chartCanvas) return;
     const ctx = chartCanvas.getContext("2d");
     let chart = null;
 

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -35,6 +35,13 @@ export function showTab(tab) {
 
     document.getElementById(`tab-${tab}`).classList.add("border-gray-800");
     document.getElementById(`tab-${tab}`).classList.remove("border-transparent");
+
+    const dropdownElement = document.getElementById("historicTabDropdown")
+    if (tab === "graph") {
+        dropdownElement.style.visibility = ""
+    } else {
+        dropdownElement.style.visibility = "hidden"
+    }
 }
 
 export function restrictCustomKeyFigureAccess() {

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -261,6 +261,24 @@ function insertKeyFigureNamesIntoDropdownLabel() {
 
 }
 
+function markSelectedCustomKeyFiguresAsChecked() {
+    /**
+     * Inside the dropdown menu in the historic graph tab, custom key figures
+     * are loaded dynamically when the page loads.
+     * For this reason, they appear as unchecked after a page refresh even if they are still selected.
+     * This function iterates over all key figures in the dropdown marks their checkboxes as checked, if they
+     * are selected in the URL parameter selectedKeyFigures.
+     */
+    const selectedKeyFigures = getSelectedKeyFiguresFromUrlParams()
+    Array.from(document.getElementsByClassName("key-figure-checkbox")).forEach(checkbox => {
+        const checkBoxKeyFigure = checkbox.value
+        if (selectedKeyFigures.includes(checkBoxKeyFigure) && checkbox.checked === false) {
+            // If the key figure is selected in the URL but its checkbox is unchecked:
+            checkbox.checked = true // mark it as checked
+        }
+    })
+}
+
 function getSelectedKeyFiguresFromUrlParams() {
     const url = new URL(window.location.href)
     const urlList = decodeURIComponent(url.searchParams.get("selectedKeyFigures"))
@@ -315,6 +333,7 @@ async function setupDropdown(companyId) {
 
     setupCheckboxListeners(dropdownList, dropdownLabel, ctx, chartCanvas, companyId, labelToKey, setChart, getChart);
     insertKeyFigureNamesIntoDropdownLabel()
+    markSelectedCustomKeyFiguresAsChecked()
 
     const selectedKeyFigures = getSelectedKeyFiguresFromUrlParams()
     if (selectedKeyFigures.length > 0) {

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -102,6 +102,12 @@ export async function insertKeyFiguresToTable(data) {
 }
 
 function displayNoKeyFiguresSelectedMessage() {
+    /**
+     * Hides the empty historic chart element in the historic tab and inserts a message which informs the
+     * user that he needs to select a key figure in order to have the graph display data.
+     *
+     * @returns {void}
+     */
     const chartCanvas = document.getElementById("historicChart")
     if (chartCanvas) {
         chartCanvas.classList.add("hidden")
@@ -118,6 +124,12 @@ function displayNoKeyFiguresSelectedMessage() {
 }
 
 async function findCustomKeyFigure(customKeyFigureName) {
+    /**
+     * Searches for a custom key figure by name via the API and returns the object if found.
+     *
+     * @param {String} customKeyFigureName - The name of the searched custom key figure
+     * @returns {Object|void} The found custom key figure or nothing, if none was found
+     */
     const customKeyFigures = await sendServerRequest("GET", "http://localhost:5000/customKeyFigures", null, false)
     customKeyFigures.forEach(customKeyFigure => {
         if (customKeyFigure.name === customKeyFigureName) {
@@ -264,9 +276,16 @@ function setupCheckboxListeners(container, dropdownLabel, ctx, chartCanvas, comp
 }
 
 function updateSelectedKeyFiguresInUrlParams() {
+    /**
+     * Iterates over all key figures inside the dropdown menu in the historic tab
+     * and saves the selected ones in the URL-parameter selectedKeyFigures.
+     *
+     * @returns {void}
+     */
     const selectedKeyFigures = []
     Array.from(document.getElementsByClassName("key-figure-checkbox")).forEach(checkbox => {
         if (checkbox.checked === true) {
+            // The english name of the key figure is stored inside the value attribute of the checkbox
             const keyFigureName = checkbox.value
             selectedKeyFigures.push(keyFigureName)
         }
@@ -276,6 +295,7 @@ function updateSelectedKeyFiguresInUrlParams() {
 
     const url = new URL(window.location.href)
     if (uriEncodedList.length === 0) {
+        // If no key figures are selected, the URL-parameter is deleted to avoid errors
         url.searchParams.delete("selectedKeyFigures")
     } else {
         url.searchParams.set("selectedKeyFigures", uriEncodedList)
@@ -284,11 +304,19 @@ function updateSelectedKeyFiguresInUrlParams() {
 }
 
 function insertKeyFigureNamesIntoDropdownLabel() {
+    /**
+     * Inserts the german translations of the selected key figure names into the label of the dropdown
+     * so that the user can instantly see which key figures he has selected.
+     *
+     * @returns {void}
+     */
+
     const selectedKeyFigures = getSelectedKeyFiguresFromUrlParams()
     const dropdownLabel = document.getElementById("dropdownLabel")
     const keyFigureNamesToInsert = []
 
     selectedKeyFigures.forEach(keyFigure => {
+        // Translate the key figure name or leave the original name if no translation exists (custom key figures)
         const translation = keyFigureNames[keyFigure] || keyFigure
         keyFigureNamesToInsert.push(translation)
     })
@@ -320,6 +348,11 @@ function markSelectedCustomKeyFiguresAsChecked() {
 }
 
 function getSelectedKeyFiguresFromUrlParams() {
+    /**
+     * Reads the list of all selected key figures inside the URL parameter selectedKeyFigures.
+     *
+     * @returns {Array} A list of selected key figure names
+     */
     const url = new URL(window.location.href)
     const urlList = decodeURIComponent(url.searchParams.get("selectedKeyFigures"))
     if (urlList === "null") {

--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -18,6 +18,8 @@ export function showTab(tab) {
 }
 
 export function restrictCustomKeyFigureAccess() {
+    /* Due to reformatting of the file, this function appears so be authored by laiba-bzz in the git blame.
+       The original author is Jan (kaf212). */
     const button = document.getElementById("customKeyFigureEditorButton")
     if (!button) return;
     checkUserPrivileges().then((result) => {


### PR DESCRIPTION
Added the following fixes and improvements to the historic graph tab implementation by @laiba-bzz:

- Selected key figures will now be saved in a URL parameter, so the user's selection will not be lost after a page refresh or a visit of a different subpage like the custom figure builder. 
- When switching between companies, the selection of key figures remains and is loaded into the new graph. This enables direct comparison between companies.
- The selected view (current or historic) is also saved as a URL parameter and will persist after a refresh.
- Historic key figure values are multiplied with 100 or 1000 depending on their type (percentage or numeric).
- The dropdown menu for the key figure selection will now be hidden if the user is viewing the current tab.