### PR TITLE
Back to main page button

### DIFF
--- a/public/custom_figure.html
+++ b/public/custom_figure.html
@@ -12,10 +12,12 @@
   <script type="module" src="../src/js/pages/customFigureBuilder.js" defer></script>
   <script type="module" src="../src/js/components/customKeyFigureSidebar.js" defer></script>
   <script type="module" src="../src/js/auth/auth.js" defer></script>
+  <script type="module" src="../src/js/components/mainPageButton.js" defer></script>
+
 
 </head>
 <body>
-<button id="top-left-button">← Hauptseite</button>
+<button id="backToMainPageButton">← Hauptseite</button>
 
 <div class="content-wrapper">
   <div class="main-container">

--- a/public/custom_figure.html
+++ b/public/custom_figure.html
@@ -8,12 +8,15 @@
   <link rel="stylesheet" href="../src/styles/custome_figure.css" />
   <link rel="stylesheet" href="../src/styles/sidebar.css" />
   <link rel="stylesheet" href="../src/styles/infobox.css">
+  <link rel="stylesheet" href="../src/styles/main_page_button.css">
   <script type="module" src="../src/js/pages/customFigureBuilder.js" defer></script>
   <script type="module" src="../src/js/components/customKeyFigureSidebar.js" defer></script>
   <script type="module" src="../src/js/auth/auth.js" defer></script>
 
 </head>
 <body>
+<button id="top-left-button">← Hauptseite</button>
+
 <div class="content-wrapper">
   <div class="main-container">
 

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -6,11 +6,12 @@
   <title>Datenschutz</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="module" src="../src/js/auth/auth.js" defer></script>
+  <script src='../src/js/components/mainPageButton.js' defer></script>
   <link rel="stylesheet" href="../src/styles/styles.css">
   <link rel="stylesheet" href="../src/styles/main_page_button.css">
 </head>
 <body class="bg-gray-100 flex flex-col items-center p-4 min-h-screen">
-<button id="top-left-button">← Hauptseite</button>
+<button id="backToMainPageButton">← Hauptseite</button>
 
 <div class="main-container">
   <h1 class="text-xl font-bold mb-4">Datenschutzerklärung</h1>

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -28,7 +28,6 @@
   <h2 class="font-bold mt-4">3. Ihre Rechte</h2>
   <p>Sie haben das Recht auf Auskunft, Berichtigung, Löschung und Widerspruch gegen die Verarbeitung Ihrer Daten.</p>
 
-  <p class="mt-4"><a onclick="window.location = document.referrer" class="button">Zurück</a></p>
 </div>
 
 </body>

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -7,8 +7,10 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="module" src="../src/js/auth/auth.js" defer></script>
   <link rel="stylesheet" href="../src/styles/styles.css">
+  <link rel="stylesheet" href="../src/styles/main_page_button.css">
 </head>
 <body class="bg-gray-100 flex flex-col items-center p-4 min-h-screen">
+<button id="top-left-button">← Hauptseite</button>
 
 <div class="main-container">
   <h1 class="text-xl font-bold mb-4">Datenschutzerklärung</h1>

--- a/public/import.html
+++ b/public/import.html
@@ -9,8 +9,10 @@
   <script type="module" src="../src/js/pages/fileImport.js" defer></script>
   <link rel="stylesheet" href="../src/styles/styles.css">
   <link rel="stylesheet" href="../src/styles/infobox.css">
+  <link rel="stylesheet" href="../src/styles/main_page_button.css">
 </head>
 <body class="bg-gray-100 flex flex-col items-center justify-center h-screen">
+<button id="top-left-button">← Hauptseite</button>
 
 <div class="infobox-overlay" id="infoBoxOverlay">
   <div class="infobox"></div>

--- a/public/import.html
+++ b/public/import.html
@@ -7,12 +7,13 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="module" src="../src/js/auth/auth.js" defer></script>
   <script type="module" src="../src/js/pages/fileImport.js" defer></script>
+  <script type="module" src="../src/js/components/mainPageButton.js" defer></script>
   <link rel="stylesheet" href="../src/styles/styles.css">
   <link rel="stylesheet" href="../src/styles/infobox.css">
   <link rel="stylesheet" href="../src/styles/main_page_button.css">
 </head>
 <body class="bg-gray-100 flex flex-col items-center justify-center h-screen">
-<button id="top-left-button">← Hauptseite</button>
+<button id="backToMainPageButton">← Hauptseite</button>
 
 <div class="infobox-overlay" id="infoBoxOverlay">
   <div class="infobox"></div>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -7,8 +7,11 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="module" src="../src/js/auth/auth.js" defer></script>
   <link rel="stylesheet" href="../src/styles/styles.css">
+  <link rel="stylesheet" href="../src/styles/main_page_button.css">
 </head>
 <body class="bg-gray-100 flex flex-col items-center p-4 min-h-screen">
+<button id="top-left-button">← Hauptseite</button>
+
 
 <div class="main-container">
   <h1 class="text-xl font-bold mb-4">Impressum</h1>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -6,11 +6,12 @@
   <title>Impressum</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="module" src="../src/js/auth/auth.js" defer></script>
+  <script src='../src/js/components/mainPageButton.js' defer></script>
   <link rel="stylesheet" href="../src/styles/styles.css">
   <link rel="stylesheet" href="../src/styles/main_page_button.css">
 </head>
 <body class="bg-gray-100 flex flex-col items-center p-4 min-h-screen">
-<button id="top-left-button">← Hauptseite</button>
+<button id="backToMainPageButton">← Hauptseite</button>
 
 
 <div class="main-container">

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -23,7 +23,6 @@
   <p>Schweiz</p>
   <p>Geschäftsführer: Jan Atzgerstorfer</p>
   <p>Email: info@kennzahlen-cockpit.ch</p>
-  <p class="mt-4"><a onclick="window.location = document.referrer;" class="button">Zurück</a></p>
 </div>
 
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -61,7 +61,7 @@
 
       <div class="flex space-x-2">
         <a id="customKeyFigureEditorButton" class="greyed-out custom-button bg-blue-400 text-white px-4 py-2 rounded hover:bg-blue-300 transition">Neue Kennzahl</a>
-        <a id="excelImportButton" class="import-button bg-emerald-400 text-white px-4 py-2 rounded hover:bg-emerald-300 transition">Excel Import</a>
+        <a href='import.html' class="import-button bg-emerald-400 text-white px-4 py-2 rounded hover:bg-emerald-300 transition">Excel Import</a>
       </div>
     </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -61,7 +61,7 @@
 
       <div class="flex space-x-2">
         <a id="customKeyFigureEditorButton" class="greyed-out custom-button bg-blue-400 text-white px-4 py-2 rounded hover:bg-blue-300 transition">Neue Kennzahl</a>
-        <a href="import.html" class="import-button bg-emerald-400 text-white px-4 py-2 rounded hover:bg-emerald-300 transition">Excel Import</a>
+        <a id="excelImportButton" class="import-button bg-emerald-400 text-white px-4 py-2 rounded hover:bg-emerald-300 transition">Excel Import</a>
       </div>
     </div>
 

--- a/src/js/components/mainPageButton.js
+++ b/src/js/components/mainPageButton.js
@@ -5,7 +5,7 @@ function addMainPageButtonEventListener() {
         const referrerUrl = new URL(document.referrer)
         const mainPageUrl = new URL("index.html", window.location.origin)
 
-        referrerUrl.searchParams.forEach((param, value) => {
+        referrerUrl.searchParams.forEach((value, param) => {
             mainPageUrl.searchParams.set(param, value)
         })
 

--- a/src/js/components/mainPageButton.js
+++ b/src/js/components/mainPageButton.js
@@ -1,0 +1,16 @@
+
+function addMainPageButtonEventListener() {
+    const button = document.getElementById("backToMainPageButton")
+    button.addEventListener("click", ()=>{
+        const referrerUrl = new URL(document.referrer)
+        const mainPageUrl = new URL("index.html", window.location.origin)
+
+        referrerUrl.searchParams.forEach((param, value) => {
+            mainPageUrl.searchParams.set(param, value)
+        })
+
+        window.location = mainPageUrl.toString()
+    })
+}
+
+addMainPageButtonEventListener()

--- a/src/styles/main_page_button.css
+++ b/src/styles/main_page_button.css
@@ -1,4 +1,4 @@
-#top-left-button {
+#backToMainPageButton {
     position: fixed;
     top: 2rem;
     left: 2rem;

--- a/src/styles/main_page_button.css
+++ b/src/styles/main_page_button.css
@@ -1,0 +1,13 @@
+#top-left-button {
+    position: fixed;
+    top: 2rem;
+    left: 2rem;
+    background-color: #007bff;
+    color: white;
+    padding: 0.5rem 1rem;
+    font-weight: bold;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+    border: none;
+    cursor: pointer;
+}


### PR DESCRIPTION
Created and implemented a "back to main page" button in all subpages and removed the old "back" buttons that could trap the user in an infinite loop between login and the respective subpage.
The new "back to main page" button...

- Always gives the user the possibility to access the main page if he has accessed the page directly via one of the subpages (for example the custom key figure builder)
- Retains the URL parameters of the main page while doing so, which keeps all the data loaded, that the user has viewed before
- Automatically refreshes the main page so that the newest version of the viewed data (new custom key figures, new uploaded data) is immediately shown.