### PR TITLE
implemented annual profit and loss into the custom key figure builder

### DIFF
--- a/src/js/pages/customFigureBuilder.js
+++ b/src/js/pages/customFigureBuilder.js
@@ -28,6 +28,7 @@ export const translations = {
         "Gewinnvortrag": "retained_earnings"
     },
    "expense": {
+        "Jahresgewinn": "earnings-expense",
        "Betriebsaufwand": "operating_expense",
        "Personalaufwand": "staff_expense",
        "Sonstiger BA": "other_expenses",
@@ -37,6 +38,7 @@ export const translations = {
        "Gesamtaufwand": "expense"
    },
     "earnings": {
+        "Jahresverlust": "earnings-expense",
         "Betriebsertrag": "operating_income",
         "Finanzertrag": "financial_income",
         "Liegenschaftsertrag": "real_estate_income",


### PR DESCRIPTION
Implemented the possibility to include the annual profit or loss into the custom key figure builder by simply parsing"Jahresgewinn" and "Jahresverlust" to "earnings-expense".

Notice:
If the company has made no losses, the annual loss will evaluate as positive number.
If the company has made no profit, the annual profit will evaluate as negative number.