### PR TITLE
Simplify annual profit calculation

### DIFF
--- a/src/js/components/customKeyFigureSidebar.js
+++ b/src/js/components/customKeyFigureSidebar.js
@@ -1,5 +1,8 @@
 import {addInfoBoxEventListener, sendServerRequest} from "../utils/serverResponseHandling.js";
-import {refreshReferenceValueTextField, translations} from "../pages/customFigureBuilder.js";
+import {
+    refreshReferenceValueTextField,
+    translations
+} from "../pages/customFigureBuilder.js";
 import {escapeHtml} from "../utils/escapeHtml.js";
 
 function reverseParseFormulaString(formulaStr) {
@@ -11,18 +14,7 @@ function reverseParseFormulaString(formulaStr) {
      * @returns {string} - The formula string translated into german with whitespaces
      */
 
-    /* Before the formula is reverse-parsed, it has to be searched for the annual profit or loss
-    formulas, because they would get destroyed during the regular reverse-parsing. (They include
-    the substrings "earnings" and "expense") */
-    const annualProfitFormula = translations["expense"]["Jahresgewinn"]
-    const annualLossFormula = translations["earnings"]["Jahresverlust"]
-
-    if (formulaStr.includes(annualLossFormula)) {
-        formulaStr = formulaStr.replace(annualLossFormula, "Jahresverlust")
-    }
-    if (formulaStr.includes(annualProfitFormula)) {
-        formulaStr = formulaStr.replace(annualProfitFormula, "Jahresgewinn")
-    }
+    formulaStr = reverseParseAnnualProfitAndLossFormulas(formulaStr)
 
     // Reverse-parse the formula by iterating over the translations object and replacing substrings.
     for (const [accountGroup, accounts] of Object.entries(translations)) {
@@ -52,6 +44,24 @@ function reverseParseFormulaString(formulaStr) {
     return formulaStr
 }
 
+
+function reverseParseAnnualProfitAndLossFormulas(formulaStr) {
+
+    /* Before the formula is reverse-parsed, it has to be searched for the annual profit or loss
+    formulas, because they would get destroyed during the regular reverse-parsing. (They include
+    the substrings "earnings" and "expense") */
+    const annualProfitFormula = translations["expense"]["Jahresgewinn"]
+    const annualLossFormula = translations["earnings"]["Jahresverlust"]
+
+    if (formulaStr.includes(annualLossFormula)) {
+        formulaStr = formulaStr.replace(annualLossFormula, "Jahresverlust")
+    }
+    if (formulaStr.includes(annualProfitFormula)) {
+        formulaStr = formulaStr.replace(annualProfitFormula, "Jahresgewinn")
+    }
+
+    return formulaStr
+}
 
 async function getCustomKeyFigures() {
     const data = await sendServerRequest("GET", "http://localhost:5000/api/customKeyFigures", null, false)

--- a/src/js/pages/customFigureBuilder.js
+++ b/src/js/pages/customFigureBuilder.js
@@ -28,7 +28,7 @@ export const translations = {
         "Gewinnvortrag": "retained_earnings"
     },
    "expense": {
-       "Jahresgewinn": "earnings-expense",
+       "Jahresgewinn": "(earnings-expense)",
        "Betriebsaufwand": "operating_expense",
        "Personalaufwand": "staff_expense",
        "Sonstiger BA": "other_expenses",

--- a/src/js/pages/customFigureBuilder.js
+++ b/src/js/pages/customFigureBuilder.js
@@ -27,9 +27,8 @@ export const translations = {
         "Ges. Gewinnreserve": "legal_reserve",
         "Gewinnvortrag": "retained_earnings"
     },
-    // Source for profit/loss calculation: https://chatgpt.com/share/68124b7f-1448-8011-96ad-64ae28f176be
    "expense": {
-        "Jahresgewinn": "(earnings-expense>0?earnings-expense:-(abs(earnings-expense)))",
+       "Jahresgewinn": "earnings-expense",
        "Betriebsaufwand": "operating_expense",
        "Personalaufwand": "staff_expense",
        "Sonstiger BA": "other_expenses",
@@ -39,6 +38,7 @@ export const translations = {
        "Gesamtaufwand": "expense"
    },
     "earnings": {
+        // Source for loss calculation: https://chatgpt.com/share/68124b7f-1448-8011-96ad-64ae28f176be
         "Jahresverlust": "(earnings-expense<0?abs(earnings-expense):-(abs(earnings-expense)))",
         "Betriebsertrag": "operating_income",
         "Finanzertrag": "financial_income",


### PR DESCRIPTION
I noticed that the special calculation formula is only necessary for the annual loss calculation, because annual profit needs to be negative when a loss was made and positive when a profit was made. This is exactly what the formula `(earnings - expense)` does.