### PR TITLE
use .replaceAll for formula parsing

### DIFF
--- a/src/js/components/customKeyFigureSidebar.js
+++ b/src/js/components/customKeyFigureSidebar.js
@@ -21,7 +21,7 @@ function reverseParseFormulaString(formulaStr) {
         for (const [germanAccount, englishAccount] of Object.entries(accounts)) {
             if (formulaStr.includes(englishAccount)) {
                 // Replace English account name with German translation
-                formulaStr = formulaStr.replace(new RegExp(englishAccount, 'g'), germanAccount)
+                formulaStr = formulaStr.replaceAll(new RegExp(englishAccount, 'g'), germanAccount)
             }
         }
     }
@@ -54,10 +54,10 @@ function reverseParseAnnualProfitAndLossFormulas(formulaStr) {
     const annualLossFormula = translations["earnings"]["Jahresverlust"]
 
     if (formulaStr.includes(annualLossFormula)) {
-        formulaStr = formulaStr.replace(annualLossFormula, "Jahresverlust")
+        formulaStr = formulaStr.replaceAll(annualLossFormula, "Jahresverlust")
     }
     if (formulaStr.includes(annualProfitFormula)) {
-        formulaStr = formulaStr.replace(annualProfitFormula, "Jahresgewinn")
+        formulaStr = formulaStr.replaceAll(annualProfitFormula, "Jahresgewinn")
     }
 
     return formulaStr

--- a/src/js/pages/customFigureBuilder.js
+++ b/src/js/pages/customFigureBuilder.js
@@ -195,7 +195,7 @@ function parseFormulaString(formulaStr) {
         for (const [germanAccount, englishAccount] of Object.entries(accounts)) {
             if (formulaStr.includes(germanAccount)) {
                 // replace german account name with english translation
-                formulaStr = formulaStr.replace(germanAccount, englishAccount)
+                formulaStr = formulaStr.replaceAll(germanAccount, englishAccount)
             }
         }
     }


### PR DESCRIPTION
Fixed issue #69 by using the `.replaceAll()` method to parse and reverse parse formula strings for custom key figures.