### PR TITLE
simplfy annual loss calculation by just negating the value

### DIFF
--- a/src/js/pages/customFigureBuilder.js
+++ b/src/js/pages/customFigureBuilder.js
@@ -38,8 +38,7 @@ export const translations = {
        "Gesamtaufwand": "expense"
    },
     "earnings": {
-        // Source for loss calculation: https://chatgpt.com/share/68124b7f-1448-8011-96ad-64ae28f176be
-        "Jahresverlust": "(earnings-expense<0?abs(earnings-expense):-(abs(earnings-expense)))",
+        "Jahresverlust": "((earnings-expense)*-1)",
         "Betriebsertrag": "operating_income",
         "Finanzertrag": "financial_income",
         "Liegenschaftsertrag": "real_estate_income",


### PR DESCRIPTION
I realized that the complicated formula for the annual loss that includes a condition to evaluate, if it should be negative or positive is completely uneccessary. The same can be achieved by just multiplying the difference between earnings and expense with -1.

I feel so stupid.