### PR TITLE
renamed Ford. L+L and Verb. L+L to FLL and VLL

### DIFF
--- a/src/js/pages/customFigureBuilder.js
+++ b/src/js/pages/customFigureBuilder.js
@@ -8,7 +8,7 @@ export const translations = {
         "Kasse": "cash",
         "Post": "postal",
         "Bank": "bank",
-        "Ford. L+L": "receivables",
+        "FLL": "receivables",
         "Warenvorrat": "stocks",
         "Anlagevermögen": "fixed_assets",
         "Maschinen": "machines",
@@ -18,7 +18,7 @@ export const translations = {
     "passives": {
         "Fremdkapital": "debt",
         "Kurzfristiges FK": "short_term",
-        "Verb. L+L": "liabilities",
+        "VLL": "liabilities",
         "Langfristiges FK": "long_term",
         "Passivdarlehen": "loans",
         "Hypothek": "mortgage",


### PR DESCRIPTION
Fixed #62 by renaming "Ford. L+L" to "FLL" and "Verb. L+L" to "VLL". Both variants are common and understandable, so this was the quickest and best solution. Account names containing arithmetic operators creates huge bug potential.