### PR TITLE
moved return statement out of .forEach in findCustomkeyFigure()

### DIFF
--- a/src/js/pages/mainPage.js
+++ b/src/js/pages/mainPage.js
@@ -224,7 +224,7 @@ function displayUserMessageInTab(message) {
 
 }
 
-async function findCustomKeyFigure(customKeyFigureName, customKeyFigureList) {
+function findCustomKeyFigure(customKeyFigureName, customKeyFigureList) {
     /**
      * Searches for a specific custom key figure in an array of custom key figures by name.
      *
@@ -233,11 +233,13 @@ async function findCustomKeyFigure(customKeyFigureName, customKeyFigureList) {
      * @returns {Object|void} The found custom key figure or nothing, if none was found
      */
 
+    let foundCustomKeyFigure
     customKeyFigureList.forEach(customKeyFigure => {
         if (customKeyFigure.name === customKeyFigureName) {
-            return customKeyFigure
+            foundCustomKeyFigure = customKeyFigure
         }
     })
+    return foundCustomKeyFigure
 }
 
 async function multiplyKeyFigureValuesBasedOnType(historicDataObject) {
@@ -268,7 +270,7 @@ async function multiplyKeyFigureValuesBasedOnType(historicDataObject) {
             yearlyValue.key_figure = (yearlyValue.key_figure * multiplicator).toFixed(0)
         })
     }
-
+    console.log(historicDataObject)
     return historicDataObject
 }
 
@@ -301,7 +303,7 @@ async function renderMultiChart(selectedLabels, ctx, chartCanvas, companyId, lab
 
         return;
     }
-
+    console.log(historicData)
     historicData = await multiplyKeyFigureValuesBasedOnType(historicData)
 
     const datasets = [];


### PR DESCRIPTION
#66 was caused by a bug inside `findCustomKeyFigure()`:
```
customKeyFigureList.forEach(customKeyFigure => {
    if (customKeyFigure.name === customKeyFigureName) {
        return customKeyFigure
    }
})
```
The found custom key figure was returned inside the callback inside the .forEach loop. So the return value was just for the callback, not the actual function. This caused `findCustomKeyFigure()` to always return `undefined`.
This lead to all the numeric custom key figures always being interpreted as percentage values, because `multiplyKeyFigureValuesBasedOnType()` calls `findCustomKeyFigure()` to determine if a key figure is regular or custom. Because  `findCustomKeyFigure()` always returned `undefined`, all custom key figures were interpreted as regular key figures and subsecuently multiplied with 100, not 1000.