### PR TITLE
replaced 401 with 403 in checkUserPrivileges()

### DIFF
--- a/src/js/utils/userPrivilegeVerification.js
+++ b/src/js/utils/userPrivilegeVerification.js
@@ -2,7 +2,7 @@ export async function checkUserPrivileges() {
     // sendServerRequest() isn't used here because this wouldn't return the responses' status code
     const response = await fetch('http://localhost:5000/api/auth/admin', {headers: {"Authorization": `Bearer ${sessionStorage.getItem("token")}`}})
     const statusCode = response.status
-    if (statusCode === 401) {
+    if (statusCode === 403) {
         return false
     }
     return true


### PR DESCRIPTION
`checkUserPrivilege()` still checked the response for a 401 to determine if the user has admin privileges or not. But the http status code was changed to 403 in the API. This fixes that issue.